### PR TITLE
Renaming scaler keyword arguments in PLS classes

### DIFF
--- a/develop/add_params_temp_pls.py
+++ b/develop/add_params_temp_pls.py
@@ -11,7 +11,7 @@ y = t_dset.iloc[:, 0].values
 x_scaler = ChemometricsScaler(1)
 y_scaler = ChemometricsScaler(1)
 
-plsmodel = ChemometricsPLS(ncomps=3, xscaler=x_scaler, yscaler=y_scaler)
+plsmodel = ChemometricsPLS(ncomps=3, x_scaler=x_scaler, y_scaler=y_scaler)
 
 plsmodel.fit(xmat, y)
 
@@ -54,7 +54,7 @@ np.savetxt('./tests/test_data/pls_cvweights.csv', cvweights, fmt='%.18e',
 
 x_scaler_par = ChemometricsScaler(1/2)
 y_scaler_par = ChemometricsScaler(1/2)
-plsmodel_par = ChemometricsPLS(ncomps=3, xscaler=x_scaler_par, yscaler=y_scaler_par)
+plsmodel_par = ChemometricsPLS(ncomps=3, x_scaler=x_scaler_par, y_scaler=y_scaler_par)
 
 plsmodel_par.fit(xmat, y)
 
@@ -67,7 +67,7 @@ np.savetxt('./tests/test_data/pls_vip_par.csv', plsmodel_par.VIP(), fmt='%.18e',
 
 x_scaler_mc = ChemometricsScaler(0)
 y_scaler_mc = ChemometricsScaler(0)
-plsmodel_mc = ChemometricsPLS(ncomps=3, xscaler=x_scaler_mc, yscaler=y_scaler_mc)
+plsmodel_mc = ChemometricsPLS(ncomps=3, x_scaler=x_scaler_mc, y_scaler=y_scaler_mc)
 
 plsmodel_mc.fit(xmat, y)
 
@@ -82,7 +82,7 @@ np.savetxt('./tests/test_data/pls_vip_mc.csv', plsmodel_mc.VIP(), fmt='%.18e',
 
 x_scaler_par = ChemometricsScaler(1/2)
 y_scaler_par = ChemometricsScaler(1/2)
-plsmodel_par = ChemometricsPLS(ncomps=3, xscaler=x_scaler_par, yscaler=y_scaler_par)
+plsmodel_par = ChemometricsPLS(ncomps=3, x_scaler=x_scaler_par, y_scaler=y_scaler_par)
 
 plsmodel_par.fit(xmat, y)
 
@@ -95,7 +95,7 @@ np.savetxt('./tests/test_data/pls_vip_par.csv', plsmodel_par.VIP(), fmt='%.18e',
 
 x_scaler_mc = ChemometricsScaler(0)
 y_scaler_mc = ChemometricsScaler(0)
-plsmodel_mc = ChemometricsPLS(ncomps=3, xscaler=x_scaler_mc, yscaler=y_scaler_mc)
+plsmodel_mc = ChemometricsPLS(ncomps=3, x_scaler=x_scaler_mc, y_scaler=y_scaler_mc)
 
 plsmodel_mc.fit(xmat, y)
 

--- a/develop/add_params_temp_plsda.py
+++ b/develop/add_params_temp_plsda.py
@@ -11,7 +11,7 @@ y = t_dset.iloc[:, 0].values
 x_scaler = ChemometricsScaler(1)
 y_scaler = ChemometricsScaler(1)
 
-plsmodel = ChemometricsPLS(ncomps=3, xscaler=x_scaler, yscaler=y_scaler)
+plsmodel = ChemometricsPLS(ncomps=3, x_scaler=x_scaler, y_scaler=y_scaler)
 
 plsmodel.fit(xmat, y)
 
@@ -54,7 +54,7 @@ np.savetxt('./tests/test_data/pls_cvweights.csv', cvweights, fmt='%.18e',
 
 x_scaler_par = ChemometricsScaler(1/2)
 y_scaler_par = ChemometricsScaler(1/2)
-plsmodel_par = ChemometricsPLS(ncomps=3, xscaler=x_scaler_par, yscaler=y_scaler_par)
+plsmodel_par = ChemometricsPLS(ncomps=3, x_scaler=x_scaler_par, y_scaler=y_scaler_par)
 
 plsmodel_par.fit(xmat, y)
 
@@ -67,7 +67,7 @@ np.savetxt('./tests/test_data/pls_vip_par.csv', plsmodel_par.VIP(), fmt='%.18e',
 
 x_scaler_mc = ChemometricsScaler(0)
 y_scaler_mc = ChemometricsScaler(0)
-plsmodel_mc = ChemometricsPLS(ncomps=3, xscaler=x_scaler_mc, yscaler=y_scaler_mc)
+plsmodel_mc = ChemometricsPLS(ncomps=3, x_scaler=x_scaler_mc, y_scaler=y_scaler_mc)
 
 plsmodel_mc.fit(xmat, y)
 
@@ -82,7 +82,7 @@ np.savetxt('./tests/test_data/pls_vip_mc.csv', plsmodel_mc.VIP(), fmt='%.18e',
 
 x_scaler_par = ChemometricsScaler(1/2)
 y_scaler_par = ChemometricsScaler(1/2)
-plsmodel_par = ChemometricsPLS(ncomps=3, xscaler=x_scaler_par, yscaler=y_scaler_par)
+plsmodel_par = ChemometricsPLS(ncomps=3, x_scaler=x_scaler_par, y_scaler=y_scaler_par)
 
 plsmodel_par.fit(xmat, y)
 
@@ -95,7 +95,7 @@ np.savetxt('./tests/test_data/pls_vip_par.csv', plsmodel_par.VIP(), fmt='%.18e',
 
 x_scaler_mc = ChemometricsScaler(0)
 y_scaler_mc = ChemometricsScaler(0)
-plsmodel_mc = ChemometricsPLS(ncomps=3, xscaler=x_scaler_mc, yscaler=y_scaler_mc)
+plsmodel_mc = ChemometricsPLS(ncomps=3, x_scaler=x_scaler_mc, y_scaler=y_scaler_mc)
 
 plsmodel_mc.fit(xmat, y)
 

--- a/pyChemometrics/ChemometricsPLS.py
+++ b/pyChemometrics/ChemometricsPLS.py
@@ -20,10 +20,10 @@ class ChemometricsPLS(BaseEstimator, RegressorMixin, TransformerMixin):
 
     :param int ncomps: Number of PLS components desired.
     :param sklearn._PLS pls_algorithm: Scikit-learn PLS algorithm to use - PLSRegression or PLSCanonical are supported.
-    :param xscaler: Scaler object for X data matrix.
-    :type xscaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
-    :param yscaler: Scaler object for the Y data vector/matrix.
-    :type yscaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
+    :param x_scaler: Scaler object for X data matrix.
+    :type x_scaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
+    :param y_scaler: Scaler object for the Y data vector/matrix.
+    :type y_scaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
     :param kwargs pls_type_kwargs: Keyword arguments to be passed during initialization of pls_algorithm.
     :raise TypeError: If the pca_algorithm or scaler objects are not of the right class.
     """
@@ -99,7 +99,7 @@ class ChemometricsPLS(BaseEstimator, RegressorMixin, TransformerMixin):
     Computational Statistics, 2007
     """
 
-    def __init__(self, ncomps=2, pls_algorithm=PLSRegression, xscaler=ChemometricsScaler(), yscaler=None,
+    def __init__(self, ncomps=2, pls_algorithm=PLSRegression, x_scaler=ChemometricsScaler(), y_scaler=None,
                  **pls_type_kwargs):
 
         try:
@@ -108,16 +108,16 @@ class ChemometricsPLS(BaseEstimator, RegressorMixin, TransformerMixin):
             pls_algorithm = pls_algorithm(ncomps, scale=False, **pls_type_kwargs)
             if not isinstance(pls_algorithm, (BaseEstimator)):
                 raise TypeError("Scikit-learn model please")
-            if not (isinstance(xscaler, TransformerMixin) or xscaler is None):
+            if not (isinstance(x_scaler, TransformerMixin) or x_scaler is None):
                 raise TypeError("Scikit-learn Transformer-like object or None")
-            if not (isinstance(yscaler, TransformerMixin) or yscaler is None):
+            if not (isinstance(y_scaler, TransformerMixin) or y_scaler is None):
                 raise TypeError("Scikit-learn Transformer-like object or None")
             # 2 blocks of data = two scaling options
-            if xscaler is None:
-                xscaler = ChemometricsScaler(0, with_std=False)
+            if x_scaler is None:
+                x_scaler = ChemometricsScaler(0, with_std=False)
                 # Force scaling to false, as this will be handled by the provided scaler or not
-            if yscaler is None:
-                yscaler = ChemometricsScaler(0, with_std=False)
+            if y_scaler is None:
+                y_scaler = ChemometricsScaler(0, with_std=False)
 
             self.pls_algorithm = pls_algorithm
             # Most initialized as None, before object is fitted...
@@ -134,8 +134,8 @@ class ChemometricsPLS(BaseEstimator, RegressorMixin, TransformerMixin):
             self.beta_coeffs = None
 
             self._ncomps = ncomps
-            self._x_scaler = xscaler
-            self._y_scaler = yscaler
+            self._x_scaler = x_scaler
+            self._y_scaler = y_scaler
             self.cvParameters = None
             self.modelParameters = None
             self._isfitted = False

--- a/pyChemometrics/ChemometricsPLSDA.py
+++ b/pyChemometrics/ChemometricsPLSDA.py
@@ -23,10 +23,10 @@ class ChemometricsPLSDA(ChemometricsPLS, ClassifierMixin):
 
     :param int ncomps: Number of PLS components desired.
     :param sklearn._PLS pls_algorithm: Scikit-learn PLS algorithm to use - PLSRegression or PLSCanonical are supported.
-    :param xscaler: Scaler object for X data matrix.
-    :type xscaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
-    :param yscaler: Scaler object for the Y data vector/matrix.
-    :type yscaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
+    :param x_scaler: Scaler object for X data matrix.
+    :type x_scaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
+    :param y_scaler: Scaler object for the Y data vector/matrix.
+    :type y_scaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
     :param kwargs pls_type_kwargs: Keyword arguments to be passed during initialization of pls_algorithm.
     :raise TypeError: If the pca_algorithm or scaler objects are not of the right class.
     """
@@ -48,13 +48,13 @@ class ChemometricsPLSDA(ChemometricsPLS, ClassifierMixin):
     """
 
     def __init__(self, ncomps=2, pls_algorithm=PLSRegression,
-                 xscaler=ChemometricsScaler(scale_power=1), **pls_type_kwargs):
+                 x_scaler=ChemometricsScaler(scale_power=1), **pls_type_kwargs):
         """
 
         :param ncomps:
         :param pls_algorithm:
         :param logreg_algorithm:
-        :param xscaler:
+        :param x_scaler:
         :param pls_type_kwargs:
         """
         try:
@@ -62,12 +62,12 @@ class ChemometricsPLSDA(ChemometricsPLS, ClassifierMixin):
             pls_algorithm = pls_algorithm(ncomps, scale=False, **pls_type_kwargs)
             if not isinstance(pls_algorithm, (BaseEstimator)):
                 raise TypeError("Scikit-learn model please")
-            if not (isinstance(xscaler, TransformerMixin) or xscaler is None):
+            if not (isinstance(x_scaler, TransformerMixin) or x_scaler is None):
                 raise TypeError("Scikit-learn Transformer-like object or None")
 
             # 2 blocks of data = two scaling options in PLS but here...
-            if xscaler is None:
-                xscaler = ChemometricsScaler(0, with_std=False)
+            if x_scaler is None:
+                x_scaler = ChemometricsScaler(0, with_std=False)
 
             # Secretly declared here so calling methods from parent ChemometricsPLS class is possible
             self._y_scaler = ChemometricsScaler(0, with_std=False, with_mean=True)
@@ -91,7 +91,7 @@ class ChemometricsPLSDA(ChemometricsPLS, ClassifierMixin):
             self.n_classes = None
             self.class_means = None
             self._ncomps = ncomps
-            self._x_scaler = xscaler
+            self._x_scaler = x_scaler
             self.cvParameters = None
             self.modelParameters = None
             self._isfitted = False

--- a/pyChemometrics/ChemometricsPLS_LDA.py
+++ b/pyChemometrics/ChemometricsPLS_LDA.py
@@ -22,14 +22,14 @@ class ChemometricsPLS_LDA(ChemometricsPLS, ClassifierMixin):
 
     :param int ncomps: Number of PLS components desired.
     :param sklearn._PLS pls_algorithm: Scikit-learn PLS algorithm to use - PLSRegression or PLSCanonical are supported.
-    :param xscaler: Scaler object for X data matrix.
-    :type xscaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
-    :param yscaler: Scaler object for the Y data vector/matrix.
-    :type yscaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
+    :param x_scaler: Scaler object for X data matrix.
+    :type x_scaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
+    :param y_scaler: Scaler object for the Y data vector/matrix.
+    :type y_scaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
     :param kwargs classifier_kwargs: Keyword arguments to be passed during initialization of pls_algorithm.
     :raise TypeError: If the pca_algorithm or scaler objects are not of the right class.
     """
-    def __init__(self, ncomps=2, pls_algorithm=PLSRegression, da_algorithm=QuadraticDiscriminantAnalysis, xscaler=ChemometricsScaler(), yscaler=None,
+    def __init__(self, ncomps=2, pls_algorithm=PLSRegression, da_algorithm=QuadraticDiscriminantAnalysis, x_scaler=ChemometricsScaler(), y_scaler=None,
                  **classifier_kwargs):
 
         try:
@@ -41,16 +41,16 @@ class ChemometricsPLS_LDA(ChemometricsPLS, ClassifierMixin):
             da_algorithm = da_algorithm(**classifier_kwargs)
             if not isinstance(da_algorithm, (LinearDiscriminantAnalysis, QuadraticDiscriminantAnalysis)):
                 raise TypeError("Scikit-learn model please")
-            if not (isinstance(xscaler, TransformerMixin) or xscaler is None):
+            if not (isinstance(x_scaler, TransformerMixin) or x_scaler is None):
                 raise TypeError("Scikit-learn Transformer-like object or None")
-            if not (isinstance(yscaler, TransformerMixin) or yscaler is None):
+            if not (isinstance(y_scaler, TransformerMixin) or y_scaler is None):
                 raise TypeError("Scikit-learn Transformer-like object or None")
             # 2 blocks of data = two scaling options
-            if xscaler is None:
-                xscaler = ChemometricsScaler(0, with_std=False)
+            if x_scaler is None:
+                x_scaler = ChemometricsScaler(0, with_std=False)
                 # Force scaling to false, as this will be handled by the provided scaler or not
-            if yscaler is None:
-                yscaler = ChemometricsScaler(0, with_std=False)
+            if y_scaler is None:
+                y_scaler = ChemometricsScaler(0, with_std=False)
 
             self.pls_algorithm = pls_algorithm
             self.da_algorithm = da_algorithm
@@ -68,8 +68,8 @@ class ChemometricsPLS_LDA(ChemometricsPLS, ClassifierMixin):
             self.beta_coeffs = None
 
             self._ncomps = ncomps
-            self._x_scaler = xscaler
-            self._y_scaler = yscaler
+            self._x_scaler = x_scaler
+            self._y_scaler = y_scaler
             self.cvParameters = None
             self.modelParameters = None
             self._isfitted = False

--- a/pyChemometrics/ChemometricsPLS_Logistic.py
+++ b/pyChemometrics/ChemometricsPLS_Logistic.py
@@ -23,10 +23,10 @@ class ChemometricsPLS_Logistic(ChemometricsPLS, ClassifierMixin):
 
     :param int ncomps: Number of PLS components desired.
     :param sklearn._PLS pls_algorithm: Scikit-learn PLS algorithm to use - PLSRegression or PLSCanonical are supported.
-    :param xscaler: Scaler object for X data matrix.
-    :type xscaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
-    :param yscaler: Scaler object for the Y data vector/matrix.
-    :type yscaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
+    :param x_scaler: Scaler object for X data matrix.
+    :type x_scaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
+    :param y_scaler: Scaler object for the Y data vector/matrix.
+    :type y_scaler: ChemometricsScaler object, scaling/preprocessing objects from scikit-learn or None.
     :param kwargs pls_type_kwargs: Keyword arguments to be passed during initialization of pls_algorithm.
     :raise TypeError: If the pca_algorithm or scaler objects are not of the right class.
     """
@@ -47,14 +47,14 @@ class ChemometricsPLS_Logistic(ChemometricsPLS, ClassifierMixin):
     """
 
     def __init__(self, ncomps=2, pls_algorithm=PLSRegression, logreg_algorithm=LogisticRegression,
-                 xscaler=ChemometricsScaler(), **pls_type_kwargs):
+                 x_scaler=ChemometricsScaler(), **pls_type_kwargs):
 
         try:
             # Perform the check with is instance but avoid abstract base class runs.
             pls_algorithm = pls_algorithm(ncomps, scale=False, **pls_type_kwargs)
             if not isinstance(pls_algorithm, (BaseEstimator)):
                 raise TypeError("Scikit-learn model please")
-            if not (isinstance(xscaler, TransformerMixin) or xscaler is None):
+            if not (isinstance(x_scaler, TransformerMixin) or x_scaler is None):
                 raise TypeError("Scikit-learn Transformer-like object or None")
 
             # Not important for this classifier, but "secretly" declared here so calling methods from parent
@@ -66,8 +66,8 @@ class ChemometricsPLS_Logistic(ChemometricsPLS, ClassifierMixin):
             if not isinstance(logreg_algorithm, (BaseEstimator, LogisticRegression)):
                 raise TypeError("Scikit-learn LogisticRegression please")
             # 2 blocks of data = two scaling options
-            if xscaler is None:
-                xscaler = ChemometricsScaler(0, with_std=False)
+            if x_scaler is None:
+                x_scaler = ChemometricsScaler(0, with_std=False)
                 # Force scaling to false, as this will be handled by the provided scaler or not
             # in these PLS + Logistic/LDA the y scaling will not be used anyway, but in the future might be
 
@@ -89,7 +89,7 @@ class ChemometricsPLS_Logistic(ChemometricsPLS, ClassifierMixin):
             self.n_classes = None
 
             self._ncomps = ncomps
-            self._x_scaler = xscaler
+            self._x_scaler = x_scaler
             self.cvParameters = None
             self.modelParameters = None
             self._isfitted = False
@@ -119,7 +119,7 @@ class ChemometricsPLS_Logistic(ChemometricsPLS, ClassifierMixin):
             # Scaling for the classifier setting proceeds as usual for the X block
             xscaled = self.x_scaler.fit_transform(x)
 
-            # For this "classifier" PLS objects, the yscaler is not used, as we are not interesting in decentering and
+            # For this "classifier" PLS objects, the y_scaler is not used, as we are not interesting in decentering and
             # scaling class labels and dummy matrices.
 
             # Instead, we just do some on the fly detection of binary vs multiclass classification

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='pyChemometrics',
-    version='0.13.5',
+    version='0.13.6dev',
     packages=['pyChemometrics'],
     url='https://github.com/Gscorreia89/pyChemometrics/',
     documentation='http://pychemometrics.readthedocs.io/en/stable/',

--- a/tests/develop_tests/test_pls_da.py
+++ b/tests/develop_tests/test_pls_da.py
@@ -42,8 +42,8 @@ class TestPLSDA(unittest.TestCase):
 
         x_scaler = ChemometricsScaler(1)
         y_scaler = ChemometricsScaler(1, with_mean=True, with_std=False)
-        self.plsda = ChemometricsPLSDA(n_comps=3, xscaler=x_scaler, y_scaler=y_scaler)
-        self.plsda_multiy = ChemometricsPLSDA(n_comps=3, xscaler=x_scaler, y_scaler=y_scaler)
+        self.plsda = ChemometricsPLSDA(n_comps=3, x_scaler=x_scaler, y_scaler=y_scaler)
+        self.plsda_multiy = ChemometricsPLSDA(n_comps=3, x_scaler=x_scaler, y_scaler=y_scaler)
 
     def test_single_y(self):
         """

--- a/tests/develop_tests/test_pls_logistic.py
+++ b/tests/develop_tests/test_pls_logistic.py
@@ -20,7 +20,7 @@ class test_plslogistic(unittest.TestCase):
         self.twoclass_dataset = make_classification(40, n_features=100, n_informative=5, n_redundant=5, n_classes=2)
         self.three_classdataset = make_classification(40, n_features=100, n_informative=5, n_redundant=5, n_classes=3)
         y_scaler = ChemometricsScaler(with_mean=False, with_std=False)
-        self.plsreg = ChemometricsPLS(n_comps=3, yscaler=y_scaler)
+        self.plsreg = ChemometricsPLS(n_comps=3, y_scaler=y_scaler)
         self.plslog = ChemometricsPLS_Logistic(n_comps=3)
 
     def test_single_y(self):

--- a/tests/develop_tests/test_pls_qda.py
+++ b/tests/develop_tests/test_pls_qda.py
@@ -20,7 +20,7 @@ class test_plsobjconsistency(unittest.TestCase):
         self.twoclass_dataset = make_classification(40, n_features=100, n_informative=5, n_redundant=5, n_classes=2)
         self.three_classdataset = make_classification(40, n_features=100, n_informative=5, n_redundant=5, n_classes=3)
         y_scaler = ChemometricsScaler(with_mean=False, with_std=False)
-        self.plsreg = ChemometricsPLS(n_comps=3, yscaler=y_scaler)
+        self.plsreg = ChemometricsPLS(n_comps=3, y_scaler=y_scaler)
         self.plslog = ChemometricsPLS_Logistic(n_comps=3)
 
     def test_single_y(self):

--- a/tests/test_pls_regression.py
+++ b/tests/test_pls_regression.py
@@ -89,8 +89,8 @@ class TestPLS(unittest.TestCase):
 
         x_scaler = ChemometricsScaler(1)
         y_scaler = ChemometricsScaler(1)
-        self.plsreg = ChemometricsPLS(ncomps=3, xscaler=x_scaler, yscaler=y_scaler)
-        self.plsreg_multiblock = ChemometricsPLS(ncomps=3, xscaler=x_scaler, yscaler=y_scaler)
+        self.plsreg = ChemometricsPLS(ncomps=3, x_scaler=x_scaler, y_scaler=y_scaler)
+        self.plsreg_multiblock = ChemometricsPLS(ncomps=3, x_scaler=x_scaler, y_scaler=y_scaler)
 
     def test_single_y(self):
         """
@@ -136,10 +136,10 @@ class TestPLS(unittest.TestCase):
         x_scaler_mc = ChemometricsScaler(0)
         y_scaler_mc = ChemometricsScaler(0)
 
-        pareto_model = ChemometricsPLS(ncomps=3, xscaler=x_scaler_par, yscaler=y_scaler_par)
-        pareto_model_multiy = ChemometricsPLS(ncomps=3, xscaler=x_scaler_par, yscaler=y_scaler_par)
-        mc_model = ChemometricsPLS(ncomps=3, xscaler=x_scaler_mc, yscaler=y_scaler_mc)
-        mc_model_multiy = ChemometricsPLS(ncomps=3, xscaler=x_scaler_mc, yscaler=y_scaler_mc)
+        pareto_model = ChemometricsPLS(ncomps=3, x_scaler=x_scaler_par, y_scaler=y_scaler_par)
+        pareto_model_multiy = ChemometricsPLS(ncomps=3, x_scaler=x_scaler_par, y_scaler=y_scaler_par)
+        mc_model = ChemometricsPLS(ncomps=3, x_scaler=x_scaler_mc, y_scaler=y_scaler_mc)
+        mc_model_multiy = ChemometricsPLS(ncomps=3, x_scaler=x_scaler_mc, y_scaler=y_scaler_mc)
 
         pareto_model.fit(self.xmat, self.y)
         pareto_model_multiy.fit(self.xmat_multiy, self.ymat)

--- a/tests/test_plsobjconsistency.py
+++ b/tests/test_plsobjconsistency.py
@@ -47,7 +47,7 @@ class TestPLSObjectConsistency(unittest.TestCase):
 
         # Set up the same scalers
         y_scaler = ChemometricsScaler(0, with_std=False, with_mean=True)
-        self.plsreg = ChemometricsPLS(ncomps=3, yscaler=y_scaler)
+        self.plsreg = ChemometricsPLS(ncomps=3, y_scaler=y_scaler)
         self.plsda = ChemometricsPLSDA(ncomps=3)
 
         # Generate the dummy matrix so we can run the pls regression objects in the same conditions as


### PR DESCRIPTION
Calling any function relying on `sklearn.base.BaseEstimator.get_params()` for any of the PLS classes currently results in an attribute error (see below). Examples include `self.__repr__()`, invoked by via `ChemometricsPLS()`.

This behavior is caused by the values passed as keyword arguments xscaler and yscaler being assigned to attributes x_scaler, y_scaler, respectively. As `BaseEstimator.get_params()` expects all keyword arguments to be stored as attributes with the same name, an AttributeError is raised.

Current behaviour:
```python
> ChemometricsPLS().get_params()

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[97], line 2
      1 _pls = ChemometricsPLS()
----> 2 _pls.get_params()

File ~\AppData\Local\miniconda3\envs\pyChemometrics\Lib\site-packages\sklearn\base.py:194, in BaseEstimator.get_params(self, deep)
    192 out = dict()
    193 for key in self._get_param_names():
--> 194     value = getattr(self, key)
    195     if deep and hasattr(value, "get_params") and not isinstance(value, type):
    196         deep_items = value.get_params().items()

AttributeError: 'ChemometricsPLS' object has no attribute 'xscaler'
```

Expected behavior:
```python
> ChemometricsPLS().get_params()

{'ncomps': 2, 'pls_algorithm__copy': True, 'pls_algorithm__max_iter': 500, 'pls_algorithm__n_components': 2, 'pls_algorithm__scale': False, 'pls_algorithm__tol': 1e-06, 'pls_algorithm': PLSRegression(scale=False), 'x_scaler__copy': True, 'x_scaler__scale_power': 1, 'x_scaler__with_mean': True, 'x_scaler__with_std': True, 'x_scaler': ChemometricsScaler(), 'y_scaler__copy': True, 'y_scaler__scale_power': 0, 'y_scaler__with_mean': True, 'y_scaler__with_std': False, 'y_scaler': ChemometricsScaler(scale_power=0, with_std=False)}
```